### PR TITLE
Edited file to build on Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - 4.2.3
 solution: ./src/GameOfLife.sln
 install:
   - nuget restore ./src/GameOfLife.sln
@@ -13,7 +15,7 @@ install:
   - ./configure
   - make
   - sudo make install
-  - cd ../../csMACnz/Coveralls.net-Samples
+  - cd $TRAVIS_BUILD_DIR
 script:
   - xbuild /p:Configuration=Release ./src/GameOfLife.sln
   - export LD_LIBRARY_PATH=/usr/local/lib


### PR DESCRIPTION
Current versions of mono fail to compile monocov. This patch forces mono into an older version. There is also a change to use $TRAVIS_BUILD_DIR, so the file does not need to be changed if it is forked by another user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/csmacnz/coveralls.net-samples/9)
<!-- Reviewable:end -->
